### PR TITLE
Fix issue 4

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -145,6 +145,7 @@ const MyGenerator = class extends Generator {
       appNameKebabCase,
       appNameCapitalizeFirst,
       appDescription,
+      dependencies,
       privateRepository,
       githubUsername,
       githubEmail,
@@ -237,13 +238,13 @@ const MyGenerator = class extends Generator {
       this.fs.copyTpl(
         this.templatePath('demo/_index.tsx'),
         this.destinationPath(`demo/index.${useTypescript ? 'tsx' : 'jsx'}`),
-        { useTypescript }
+        { useTypescript, dependencies }
       )
     } else {
       this.fs.copyTpl(
         this.templatePath('demo/_index.ts'),
         this.destinationPath(`demo/index.${useTypescript ? 'ts' : 'js'}`),
-        { useTypescript }
+        { useTypescript, dependencies }
       )
     }
   }

--- a/generators/app/templates/demo/_index.ts
+++ b/generators/app/templates/demo/_index.ts
@@ -1,28 +1,30 @@
+<% if (dependencies.includes('tachyons')) { %>
 import 'tachyons'
-import 'tachyons-extra'
-import { hello } from '../src'
-<% if (useTypescript) { %>
-import { select, Selection } from 'd3-selection'
-<% } else { %>
-import { select } from 'd3-selection'
 <% } %>
+<% if (dependencies.includes('tachyons-extra')) { %>
+import 'tachyons-extra'
+<% } %>
+import { hello } from '../src'
 
 ///////////////////////////////////////////////////////////////////////////////
 
-const root = select('#app')
-const container = root.append('div').attr('class', 'w-100 h-100 flex flex-center')
+const root = document.getElementById('app')
+const container = document.createElement('div')
+
+container.classList.add('w-100', 'h-100', 'flex', 'flex-center')
+root.appendChild(container)
 createDemo(container)
 
 ///////////////////////////////////////////////////////////////////////////////
 
 <% if (useTypescript) { %>
-function createDemo(container: Selection<HTMLDivElement, unknown, HTMLElement, any>) {
+function createDemo(container: HTMLDivElement) {
 <% } else { %>
 function createDemo(container) {
 <% } %>
-  const example = container
-    .append('div')
-    .attr('id', 'example')
-    .attr('class', `flex flex-column`)
-    .html(hello('mitico'))
+  const example = document.createElement('div')
+  example.setAttribute('id', 'example')
+  example.classList.add('flex', 'flex-column')
+  example.innerText = hello('mitico')
+  container.appendChild(example)
 }

--- a/generators/app/templates/demo/_index.ts
+++ b/generators/app/templates/demo/_index.ts
@@ -1,35 +1,5 @@
 import 'tachyons'
 import 'tachyons-extra'
-import { hello } from '../dist/lib/hello'
-<% if (useTypescript) { %>
-import { select, Selection } from 'd3-selection'
-<% } else { %>
-import { select } from 'd3-selection'
-<% } %>
-
-///////////////////////////////////////////////////////////////////////////////
-
-const root = select('#app')
-const container = root.append('div').attr('class', 'w-100 h-100 flex flex-center')
-createDemo(container)
-
-///////////////////////////////////////////////////////////////////////////////
-
-<% if (useTypescript) { %>
-function createDemo(container: Selection<HTMLDivElement, unknown, HTMLElement, any>) {
-<% } else { %>
-function createDemo(container) {
-<% } %>
-  const example = container
-    .append('div')
-    .attr('id', 'example')
-    .attr('class', `flex flex-column`)
-    .html(hello('mitico'))
-}
-<% } %>
-  
-import 'tachyons'
-import 'tachyons-extra'
 import { hello } from '../src'
 <% if (useTypescript) { %>
 import { select, Selection } from 'd3-selection'


### PR DESCRIPTION
- Removes duplicated code in demo/_index.ts that caused generator to fail
- Adds dependencies list to the template builder in demo/_index.ts in order to avoid importing libraries if not included
- Rewrites demo/_index.ts to remove d3-selection, since d3 is not among necessary dependencies